### PR TITLE
Upgrade to send heartbeats and work on v2 execution environment

### DIFF
--- a/app.py
+++ b/app.py
@@ -13,9 +13,8 @@ logger = logging.getLogger(__name__)
 
 def run(analysis):
     logger.info("Started example analysis.")
-    time.sleep(150)
     do_something()
-    time.sleep(150)
+    time.sleep(2)
     analysis.output_values = [1, 2, 3, 4, 5]
 
     with tempfile.TemporaryDirectory() as temporary_directory:

--- a/app.py
+++ b/app.py
@@ -13,8 +13,9 @@ logger = logging.getLogger(__name__)
 
 def run(analysis):
     logger.info("Started example analysis.")
+    time.sleep(150)
     do_something()
-    time.sleep(2)
+    time.sleep(150)
     analysis.output_values = [1, 2, 3, 4, 5]
 
     with tempfile.TemporaryDirectory() as temporary_directory:

--- a/octue.yaml
+++ b/octue.yaml
@@ -9,7 +9,7 @@ services:
     maximum_instances: 10
     concurrency: 10
     branch_pattern: ^main$
-    memory: 128Mi
+    memory: 512Mi
     cpus: 1
     environment_variables:
       - name: LOREM

--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,9 @@ from setuptools import setup
 
 setup(
     name="example-service",
-    version="0.1.8",
+    version="0.1.9",
     install_requires=[
-        "octue==0.29.8",
+        "octue @ https://github.com/octue/octue-sdk-python/archive/feature/add-heartbeat-messages-to-children.zip",
     ],
     url="https://www.github.com/octue/example-service-cloud-run",
     author="cortadocodes",

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -3,7 +3,7 @@ import unittest
 from unittest.mock import patch
 
 from octue import Runner
-from octue.cloud.emulators import GoogleCloudStorageEmulatorTestResultModifier, mock_generate_signed_url
+from octue.cloud.emulators.cloud_storage import GoogleCloudStorageEmulatorTestResultModifier, mock_generate_signed_url
 from octue.resources import Manifest
 
 


### PR DESCRIPTION
# Summary

<!--- START AUTOGENERATED NOTES --->
# Contents ([#10](https://github.com/octue/example-service-cloud-run/pull/10))

### Enhancements
- Add sleeps to app to test heartbeats

### Fixes
- Update memory requirement to work with v2 execution environment

### Dependencies
- Update to latest octue

### Reversions
- Revert "ENH: Add sleeps to app to test heartbeats"

<!--- END AUTOGENERATED NOTES --->