### PR TITLE
Use octue==0.38.0

### DIFF
--- a/octue.yaml
+++ b/octue.yaml
@@ -9,7 +9,7 @@ services:
     maximum_instances: 10
     concurrency: 10
     branch_pattern: ^main$
-    memory: 128Mi
+    memory: 512Mi
     cpus: 1
     environment_variables:
       - name: LOREM

--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,9 @@ from setuptools import setup
 
 setup(
     name="example-service",
-    version="0.1.8",
+    version="0.1.9",
     install_requires=[
-        "octue==0.29.8",
+        "octue @ https://github.com/octue/octue-sdk-python/archive/fix/ensure-services-have-unique-ids.zip",
     ],
     url="https://www.github.com/octue/example-service-cloud-run",
     author="cortadocodes",

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     name="example-service",
     version="0.1.9",
     install_requires=[
-        "octue @ https://github.com/octue/octue-sdk-python/archive/fix/ensure-services-have-unique-ids.zip",
+        "octue==0.38.0",
     ],
     url="https://www.github.com/octue/example-service-cloud-run",
     author="cortadocodes",

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -3,7 +3,7 @@ import unittest
 from unittest.mock import patch
 
 from octue import Runner
-from octue.cloud.emulators import GoogleCloudStorageEmulatorTestResultModifier, mock_generate_signed_url
+from octue.cloud.emulators.cloud_storage import GoogleCloudStorageEmulatorTestResultModifier, mock_generate_signed_url
 from octue.resources import Manifest
 
 


### PR DESCRIPTION
<!--- SKIP AUTOGENERATED NOTES --->
# Contents ([#11](https://github.com/octue/example-service-cloud-run/pull/11))

### Fixes
- Update memory requirement to work with v2 execution environment

### Dependencies
- Use `octue==0.38.0`

<!--- END AUTOGENERATED NOTES --->